### PR TITLE
chore: migrate to centralized CI workflows

### DIFF
--- a/.github/workflows/auto-merge-deps.yml
+++ b/.github/workflows/auto-merge-deps.yml
@@ -1,46 +1,13 @@
 name: Auto-merge dependency PRs
 
 on:
-  pull_request_target:
-    types: [opened, synchronize, reopened]
+  pull_request:
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   auto-merge:
-    name: Auto-merge dependency PRs
-    runs-on: ubuntu-latest
-    if: github.event.pull_request.user.login == 'dependabot[bot]' || github.event.pull_request.user.login == 'renovate[bot]'
-
+    uses: netresearch/typo3-ci-workflows/.github/workflows/auto-merge-deps.yml@main
     permissions:
       contents: write
       pull-requests: write
-
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@a90bcbc6539c36a85cdfeb73f7e2f433735f215b # v2.15.0
-        with:
-          egress-policy: audit
-
-      - name: Approve PR
-        env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh pr review --approve "$PR_URL"
-
-      - name: Enable auto-merge
-        env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          # Detect allowed merge strategy
-          # Prefer squash (works with signed commit requirements, clean for single-commit PRs)
-          # then merge (also works with signed commits), then rebase (cannot be auto-signed)
-          STRATEGY=$(gh api "repos/${{ github.repository }}" --jq '
-            if .allow_squash_merge then "--squash"
-            elif .allow_merge_commit then "--merge"
-            elif .allow_rebase_merge then "--rebase"
-            else "--squash" end')
-          echo "Using merge strategy: $STRATEGY"
-          gh pr merge --auto $STRATEGY "$PR_URL"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -6,35 +6,14 @@ on:
   pull_request:
     branches: [main]
   schedule:
-    - cron: '0 6 * * 1'
+    - cron: '0 0 * * 1'
 
 permissions: {}
 
 jobs:
-  analyze:
-    name: Analyze
-    runs-on: ubuntu-latest
+  codeql:
+    uses: netresearch/typo3-ci-workflows/.github/workflows/codeql.yml@main
     permissions:
       contents: read
       security-events: write
       actions: read
-
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@a90bcbc6539c36a85cdfeb73f7e2f433735f215b # v2.15.0
-        with:
-          egress-policy: audit
-
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@89a39a4e59826350b863aa6b6252a07ad50cf83e # v4.32.4
-        with:
-          languages: actions
-          queries: security-and-quality
-
-      - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@89a39a4e59826350b863aa6b6252a07ad50cf83e # v4.32.4
-        with:
-          category: "/language:actions"

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -7,22 +7,7 @@ permissions: {}
 
 jobs:
   dependency-review:
-    name: Dependency Review
-    runs-on: ubuntu-latest
+    uses: netresearch/typo3-ci-workflows/.github/workflows/dependency-review.yml@main
     permissions:
       contents: read
       pull-requests: write
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@a90bcbc6539c36a85cdfeb73f7e2f433735f215b # v2.15.0
-        with:
-          egress-policy: audit
-
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Dependency Review
-        uses: actions/dependency-review-action@05fe4576374b728f0c523d6a13d64c25081e0803 # v4.8.3
-        with:
-          fail-on-severity: high
-          comment-summary-in-pr: always

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -1,0 +1,16 @@
+name: Greetings
+
+on:
+  issues:
+    types: [opened]
+  pull_request_target:
+    types: [opened]
+
+permissions: {}
+
+jobs:
+  greetings:
+    uses: netresearch/typo3-ci-workflows/.github/workflows/greetings.yml@main
+    permissions:
+      issues: write
+      pull-requests: write

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,14 @@
+name: PR Labeler
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions: {}
+
+jobs:
+  labeler:
+    uses: netresearch/typo3-ci-workflows/.github/workflows/labeler.yml@main
+    permissions:
+      contents: read
+      pull-requests: write

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -1,0 +1,23 @@
+name: License Check
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'composer.json'
+      - 'package.json'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'composer.json'
+      - 'package.json'
+  schedule:
+    - cron: '0 9 * * 1'
+
+permissions: {}
+
+jobs:
+  license-check:
+    uses: netresearch/typo3-ci-workflows/.github/workflows/license-check.yml@main
+    permissions:
+      contents: read

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -1,0 +1,15 @@
+name: Lock Threads
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  lock:
+    uses: netresearch/typo3-ci-workflows/.github/workflows/lock.yml@main
+    permissions:
+      issues: write
+      pull-requests: write

--- a/.github/workflows/pr-quality.yml
+++ b/.github/workflows/pr-quality.yml
@@ -1,0 +1,15 @@
+name: PR Quality Gates
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions: {}
+
+jobs:
+  pr-quality:
+    uses: netresearch/typo3-ci-workflows/.github/workflows/pr-quality.yml@main
+    permissions:
+      contents: read
+      pull-requests: write

--- a/.github/workflows/publish-to-ter.yml
+++ b/.github/workflows/publish-to-ter.yml
@@ -1,58 +1,17 @@
-name: Publish new extension version to TER
-permissions:
-  contents: read
+name: Publish to TER
 
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - '*'
+
+permissions: {}
 
 jobs:
   publish:
-    name: Publish new version to TER
-    if: startsWith(github.ref, 'refs/tags/')
-    runs-on: ubuntu-latest
-    env:
+    uses: netresearch/typo3-ci-workflows/.github/workflows/publish-to-ter.yml@main
+    permissions:
+      contents: read
+    secrets:
       TYPO3_EXTENSION_KEY: ${{ secrets.TYPO3_EXTENSION_KEY }}
-      TYPO3_API_TOKEN: ${{ secrets.TYPO3_TER_ACCESS_TOKEN }}
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@a90bcbc6539c36a85cdfeb73f7e2f433735f215b # v2.15.0
-        with:
-          egress-policy: audit
-
-      - name: Checkout repository
-        uses: actions/checkout@v6
-
-      - name: Check tag
-        run: |
-          if ! [[ ${{ github.ref }} =~ ^refs/tags/[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}$ ]]; then
-            exit 1
-          fi
-
-      - name: Get version
-        id: get-version
-        run: echo "version=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
-
-      - name: Get comment
-        id: get-comment
-        run: |
-          readonly local comment=$(git tag -n10 -l ${{ env.version }} | sed "s/^[0-9.]*[ ]*//g")
-
-          if [[ -z "${comment// }" ]]; then
-            echo "comment=Released version ${{ env.version }} of ${{ env.TYPO3_EXTENSION_KEY }} -- for details see $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/releases" >> $GITHUB_ENV
-          else
-            echo "comment=$comment -- for details see $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/releases" >> $GITHUB_ENV
-          fi
-
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: 8.3
-          extensions: intl, mbstring, json, zip, curl
-          tools: composer:v2
-
-      - name: Install tailor
-        run: composer global require typo3/tailor --prefer-dist --no-progress --no-suggest
-
-      - name: Publish to TER
-        run: php ~/.composer/vendor/bin/tailor ter:publish --comment "${{ env.comment }}" ${{ env.version }}
+      TYPO3_TER_ACCESS_TOKEN: ${{ secrets.TYPO3_TER_ACCESS_TOKEN }}

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -2,40 +2,17 @@ name: OpenSSF Scorecard
 
 on:
   push:
-    branches:
-      - main
+    branches: [main]
   schedule:
-    - cron: '25 6 * * 1'
+    - cron: '0 0 * * 1'
 
 permissions: {}
 
 jobs:
-  analysis:
-    name: Scorecard analysis
-    runs-on: ubuntu-latest
+  scorecard:
+    uses: netresearch/typo3-ci-workflows/.github/workflows/scorecard.yml@main
     permissions:
       contents: read
       security-events: write
       id-token: write
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@a90bcbc6539c36a85cdfeb73f7e2f433735f215b # v2.15.0
-        with:
-          egress-policy: audit
-
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-
-      - name: Run Scorecard
-        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
-        with:
-          results_file: results.sarif
-          results_format: sarif
-          publish_results: true
-
-      - name: Upload SARIF
-        uses: github/codeql-action/upload-sarif@89a39a4e59826350b863aa6b6252a07ad50cf83e # v4.32.4
-        with:
-          sarif_file: results.sarif
+      actions: read

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,20 @@
+name: Security
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 7 * * 1'
+
+permissions: {}
+
+jobs:
+  security:
+    uses: netresearch/typo3-ci-workflows/.github/workflows/security.yml@main
+    permissions:
+      contents: read
+      security-events: write
+    secrets:
+      GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,15 @@
+name: Stale Issues
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  stale:
+    uses: netresearch/typo3-ci-workflows/.github/workflows/stale.yml@main
+    permissions:
+      issues: write
+      pull-requests: write


### PR DESCRIPTION
## Summary
- Replace 5 local workflow implementations with centralized references to netresearch/typo3-ci-workflows
- Add 7 new community/security workflows

## Changes
| Workflow | Action |
|----------|--------|
| auto-merge-deps.yml | Replaced local → centralized |
| codeql.yml | Replaced local → centralized |
| dependency-review.yml | Replaced local → centralized |
| publish-to-ter.yml | Replaced local → centralized |
| scorecard.yml | Replaced local → centralized |
| pr-quality.yml | Added new |
| security.yml | Added new |
| stale.yml | Added new |
| lock.yml | Added new |
| greetings.yml | Added new |
| labeler.yml | Added new |
| license-check.yml | Added new |

## Note
Fuzz testing, release pipeline, and SLSA provenance workflows are not added because this is a legacy extension (TYPO3 10/11/12) that is not actively releasing.